### PR TITLE
Fix issue with selecting List entry by it's index

### DIFF
--- a/src/fabric-1.19.2/procedures/arraylist_get_value.java.ftl
+++ b/src/fabric-1.19.2/procedures/arraylist_get_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.get(${input$index})
+${input$var}.get((int) ${input$index})

--- a/src/fabric-1.19.2/procedures/arraylist_set_value.java.ftl
+++ b/src/fabric-1.19.2/procedures/arraylist_set_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.set(${input$index}, ${input$value});
+${input$var}.set((int) ${input$index}, ${input$value});

--- a/src/forge-1.16.5/procedures/arraylist_get_value.java.ftl
+++ b/src/forge-1.16.5/procedures/arraylist_get_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.get(${input$index})
+${input$var}.get((int) ${input$index})

--- a/src/forge-1.16.5/procedures/arraylist_set_value.java.ftl
+++ b/src/forge-1.16.5/procedures/arraylist_set_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.set(${input$index}, ${input$value});
+${input$var}.set((int) ${input$index}, ${input$value});

--- a/src/forge-1.18.2/procedures/arraylist_get_value.java.ftl
+++ b/src/forge-1.18.2/procedures/arraylist_get_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.get(${input$index})
+${input$var}.get((int) ${input$index})

--- a/src/forge-1.18.2/procedures/arraylist_set_value.java.ftl
+++ b/src/forge-1.18.2/procedures/arraylist_set_value.java.ftl
@@ -1,1 +1,1 @@
-${input$var}.set(${input$index}, ${input$value});
+${input$var}.set((int) ${input$index}, ${input$value});


### PR DESCRIPTION
By default MCreator math procedures convert numbers into Double (even if the number has zero decimal places). The "round" procedure instead converts number into Long. Both of these can't be used as an index of an array, since index is always an Integer.

This simple PR fixes that by always converting ${input$index} to int